### PR TITLE
Reverse Proxy

### DIFF
--- a/drupal8.conf
+++ b/drupal8.conf
@@ -13,6 +13,9 @@ server {
 
     location / {
 
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
         location ^~ /system/files/ {
             include fastcgi_params;
             fastcgi_param QUERY_STRING q=$uri&$args;
@@ -82,7 +85,7 @@ server {
             tcp_nodelay off;
             open_file_cache off;
         }
-        
+
         location ~* ^.+\.(?:pdf|pptx?)$ {
             expires 30d;
             tcp_nodelay off;


### PR DESCRIPTION
Adding X-Forwarded-For and X-Forwarded-Proto HTTP headers for Drupal's reverse proxy settings