### PR TITLE
Added fastcgi_buffer_size 32k

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,7 @@ http {
     include                             /etc/nginx/mime.types;
     default_type                        application/octet-stream;
     fastcgi_buffers                     256 4k;
+    fastcgi_buffer_size                 32k;
     fastcgi_intercept_errors            on;
     fastcgi_read_timeout                900;
     include                             fastcgi_params;


### PR DESCRIPTION
When enabling Drupal 8 purge module and adding Cache-Tags header then nginx gives "502 bad gateway" error message.

The error message in the nginx log is:
"upstream sent too big header while reading response header from upstream"