### PR TITLE
Updating nginx configuration to forward errors (403, 404) to application

### DIFF
--- a/11/nginx.conf
+++ b/11/nginx.conf
@@ -13,7 +13,7 @@ http {
     default_type                        application/octet-stream;
     fastcgi_buffers                     256 4k;
     fastcgi_buffer_size                 32k;
-    fastcgi_intercept_errors            on;
+    fastcgi_intercept_errors            off;
     fastcgi_read_timeout                900;
     include                             fastcgi_params;
     access_log                          /proc/self/fd/2;

--- a/14/nginx.conf
+++ b/14/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type                        application/octet-stream;
     fastcgi_buffers                     256 4k;
     fastcgi_buffer_size                 32k;
-    fastcgi_intercept_errors            on;
+    fastcgi_intercept_errors            off;
     fastcgi_read_timeout                900;
     include                             fastcgi_params;
     access_log                          /proc/self/fd/2;

--- a/16/nginx.conf
+++ b/16/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type                        application/octet-stream;
     fastcgi_buffers                     256 4k;
     fastcgi_buffer_size                 32k;
-    fastcgi_intercept_errors            on;
+    fastcgi_intercept_errors            off;
     fastcgi_read_timeout                900;
     include                             fastcgi_params;
     access_log                          /proc/self/fd/2;


### PR DESCRIPTION
Updating nginx.conf to switch fastcgi_intercept_errors parameter from **on** to **off**, so applications could catch the http code (most CMS would have custom handler for 40X errors)