### PR TITLE
Increase Nginx expires TTL

### DIFF
--- a/11/drupal8.conf
+++ b/11/drupal8.conf
@@ -33,13 +33,13 @@ server {
 
         location ~* /imagecache/ {
             access_log off;
-            expires 30d;
+            expires 1y;
             try_files $uri @drupal;
         }
 
         location ~* /files/styles/ {
             access_log off;
-            expires 30d;
+            expires 1y;
             try_files $uri @drupal;
         }
 
@@ -71,7 +71,7 @@ server {
 
         location ~* ^.+\.(?:cur|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -81,13 +81,13 @@ server {
 
         location ~* ^.+\.(?:css|js)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache off;
         }
 
         location ~* ^.+\.(?:pdf|pptx?)$ {
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
         }
 
@@ -210,7 +210,7 @@ server {
     }
 
     location = /favicon.ico {
-        expires 30d;
+        expires 1y;
         try_files /favicon.ico @empty;
     }
 
@@ -219,7 +219,7 @@ server {
     }
 
     location @empty {
-        expires 30d;
+        expires 1y;
         empty_gif;
     }
 

--- a/14/default.conf
+++ b/14/default.conf
@@ -41,7 +41,7 @@ server {
 
         location ~* /files/styles/ {
             access_log off;
-            expires 30d;
+            expires 1y;
             try_files $uri @drupal;
         }
 
@@ -83,7 +83,7 @@ server {
 
         location ~* ^.+\.(?:cur|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -93,13 +93,13 @@ server {
 
         location ~* ^.+\.(?:css|js)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache off;
         }
 
         location ~* ^.+\.(?:pdf|pptx?)$ {
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
         }
 
@@ -222,7 +222,7 @@ server {
     }
 
     location = /favicon.ico {
-        expires 30d;
+        expires 1y;
         try_files /favicon.ico @empty;
     }
 
@@ -231,7 +231,7 @@ server {
     }
 
     location @empty {
-        expires 30d;
+        expires 1y;
         empty_gif;
     }
 

--- a/16/default.conf
+++ b/16/default.conf
@@ -41,7 +41,7 @@ server {
 
         location ~* /files/styles/ {
             access_log off;
-            expires 30d;
+            expires 1y;
             try_files $uri @drupal;
         }
 
@@ -83,7 +83,7 @@ server {
 
         location ~* ^.+\.(?:cur|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -93,13 +93,13 @@ server {
 
         location ~* ^.+\.(?:css|js)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache off;
         }
 
         location ~* ^.+\.(?:pdf|pptx?)$ {
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
         }
 
@@ -222,7 +222,7 @@ server {
     }
 
     location = /favicon.ico {
-        expires 30d;
+        expires 1y;
         try_files /favicon.ico @empty;
     }
 
@@ -231,7 +231,7 @@ server {
     }
 
     location @empty {
-        expires 30d;
+        expires 1y;
         empty_gif;
     }
 

--- a/18/default.conf
+++ b/18/default.conf
@@ -41,7 +41,7 @@ server {
 
         location ~* /files/styles/ {
             access_log off;
-            expires 30d;
+            expires 1y;
             try_files $uri @drupal;
         }
 
@@ -83,7 +83,7 @@ server {
 
         location ~* ^.+\.(?:cur|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -93,13 +93,13 @@ server {
 
         location ~* ^.+\.(?:css|js)$ {
             access_log off;
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
             open_file_cache off;
         }
 
         location ~* ^.+\.(?:pdf|pptx?)$ {
-            expires 30d;
+            expires 1y;
             tcp_nodelay off;
         }
 
@@ -222,7 +222,7 @@ server {
     }
 
     location = /favicon.ico {
-        expires 30d;
+        expires 1y;
         try_files /favicon.ico @empty;
     }
 
@@ -231,7 +231,7 @@ server {
     }
 
     location @empty {
-        expires 30d;
+        expires 1y;
         empty_gif;
     }
 


### PR DESCRIPTION
Following lighthouse's recommendation:

> When possible, cache immutable static assets for a long time, such as a year or longer.

Ref https://web.dev/uses-long-cache-ttl/